### PR TITLE
Create realm support

### DIFF
--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -6,7 +6,7 @@ import { RpcContext } from '../models/core/api'
 import { sendTransaction } from '../utils/send'
 
 export async function registerRealm(
-  { connection, wallet, programId, walletPubkey }: RpcContext,
+  { connection, wallet, programId, programVersion, walletPubkey }: RpcContext,
   name: string,
   communityMint: PublicKey,
   councilMint: PublicKey | undefined,
@@ -18,6 +18,7 @@ export async function registerRealm(
   await withCreateRealm(
     instructions,
     programId,
+    programVersion,
     name,
     walletPubkey,
     communityMint,

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -1,0 +1,35 @@
+import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
+import BN from 'bn.js'
+import { MintMaxVoteWeightSource } from '../models/accounts'
+import { withCreateRealm } from '../models/withCreateRealm'
+import { RpcContext } from '../models/core/api'
+import { sendTransaction } from '../utils/send'
+
+export async function registerRealm(
+  { connection, wallet, programId, walletPubkey }: RpcContext,
+  name: string,
+  communityMint: PublicKey,
+  councilMint: PublicKey | undefined,
+  communityMintMaxVoteWeightSource: MintMaxVoteWeightSource,
+  minCommunityTokensToCreateGovernance: BN
+) {
+  const instructions: TransactionInstruction[] = []
+
+  await withCreateRealm(
+    instructions,
+    programId,
+    name,
+    walletPubkey,
+    communityMint,
+    walletPubkey,
+    councilMint,
+    communityMintMaxVoteWeightSource,
+    minCommunityTokensToCreateGovernance,
+    undefined
+  )
+
+  const transaction = new Transaction()
+  transaction.add(...instructions)
+
+  await sendTransaction({ transaction, wallet, connection })
+}

--- a/components/VoteCommentModal.tsx
+++ b/components/VoteCommentModal.tsx
@@ -43,6 +43,7 @@ const VoteCommentModal: FunctionComponent<VoteCommentModalProps> = ({
     setSubmitting(true)
     const rpcContext = new RpcContext(
       proposal!.account.owner,
+      realmInfo?.programVersion,
       wallet,
       connection.current,
       connection.endpoint

--- a/components/VotePanel.tsx
+++ b/components/VotePanel.tsx
@@ -21,7 +21,7 @@ const VotePanel = () => {
     voteRecordsByVoter,
     tokenType,
   } = useWalletStore((s) => s.selectedProposal)
-  const { ownTokenRecord, ownCouncilTokenRecord } = useRealm()
+  const { ownTokenRecord, ownCouncilTokenRecord, realmInfo } = useRealm()
   const wallet = useWalletStore((s) => s.current)
   const connection = useWalletStore((s) => s.connection)
   const { fetchVoteRecords } = useWalletStore((s) => s.actions)
@@ -62,6 +62,7 @@ const VotePanel = () => {
   const submitRelinquishVote = async () => {
     const rpcContext = new RpcContext(
       proposal!.account.owner,
+      realmInfo?.programVersion,
       wallet,
       connection.current,
       connection.endpoint

--- a/components/chat/DiscussionForm.tsx
+++ b/components/chat/DiscussionForm.tsx
@@ -15,7 +15,7 @@ import Loading from '../Loading'
 const DiscussionForm = () => {
   const [comment, setComment] = useState('')
   const connected = useWalletStore((s) => s.connected)
-  const { ownVoterWeight } = useRealm()
+  const { ownVoterWeight, realmInfo } = useRealm()
 
   const [submitting, setSubmitting] = useState(false)
 
@@ -29,6 +29,7 @@ const DiscussionForm = () => {
 
     const rpcContext = new RpcContext(
       proposal!.account.owner,
+      realmInfo?.programVersion,
       wallet,
       connection.current,
       connection.endpoint

--- a/models/accounts.ts
+++ b/models/accounts.ts
@@ -130,11 +130,15 @@ export class RealmConfigArgs {
   communityMintMaxVoteWeightSource: MintMaxVoteWeightSource
   minCommunityTokensToCreateGovernance: BN
 
+  useCommunityVoterWeightAddin: boolean
+
   constructor(args: {
     useCouncilMint: boolean
 
     communityMintMaxVoteWeightSource: MintMaxVoteWeightSource
     minCommunityTokensToCreateGovernance: BN
+
+    useCommunityVoterWeightAddin: boolean
   }) {
     this.useCouncilMint = !!args.useCouncilMint
 
@@ -143,6 +147,8 @@ export class RealmConfigArgs {
 
     this.minCommunityTokensToCreateGovernance =
       args.minCommunityTokensToCreateGovernance
+
+    this.useCommunityVoterWeightAddin = args.useCommunityVoterWeightAddin
   }
 }
 
@@ -211,6 +217,33 @@ export async function getTokenHoldingAddress(
   )
 
   return tokenHoldingAddress
+}
+
+export class RealmConfigAccount {
+  accountType = GovernanceAccountType.Realm
+
+  realm: PublicKey
+  communityVoterWeightAddin: PublicKey | undefined
+
+  constructor(args: {
+    realm: PublicKey
+    communityVoterWeightAddin: PublicKey | undefined
+  }) {
+    this.realm = args.realm
+    this.communityVoterWeightAddin = args.communityVoterWeightAddin
+  }
+}
+
+export async function getRealmConfigAddress(
+  programId: PublicKey,
+  realm: PublicKey
+) {
+  const [realmConfigAddress] = await PublicKey.findProgramAddress(
+    [Buffer.from('realm-config'), realm.toBuffer()],
+    programId
+  )
+
+  return realmConfigAddress
 }
 
 export class GovernanceConfig {

--- a/models/core/api.ts
+++ b/models/core/api.ts
@@ -5,6 +5,7 @@ import bs58 from 'bs58'
 import { ParsedAccount, ProgramAccountWithType } from '../core/accounts'
 import { Schema } from 'borsh'
 import { deserializeBorsh } from '../../utils/borsh'
+import { ProgramVersion } from '@models/registry/api'
 
 export const SYSTEM_PROGRAM_ID = new PublicKey(
   '11111111111111111111111111111111'
@@ -17,12 +18,14 @@ export interface IWallet {
 // Context to make RPC calls for given clone programId, current connection, endpoint and wallet
 export class RpcContext {
   programId: PublicKey
+  programVersion: ProgramVersion
   wallet: IWallet | undefined
   connection: Connection
   endpoint: string
 
   constructor(
     programId: PublicKey,
+    programVersion: number | undefined,
     wallet: IWallet | undefined,
     connection: Connection,
     endpoint: string
@@ -31,6 +34,7 @@ export class RpcContext {
     this.wallet = wallet
     this.connection = connection
     this.endpoint = endpoint
+    this.programVersion = programVersion || ProgramVersion.V1
   }
 
   get walletPubkey() {

--- a/models/createSetRealmConfig.ts
+++ b/models/createSetRealmConfig.ts
@@ -15,13 +15,14 @@ export async function createSetRealmConfig(
   realmAuthority: PublicKey,
   councilMint: PublicKey | undefined,
   communityMintMaxVoteWeightSource: MintMaxVoteWeightSource,
-  minCommunityTokensToCreateGovernance: BN
+  minCommunityTokensToCreateGovernance: BN,
+  communityVoterWeightAddin: PublicKey | undefined
 ) {
   const configArgs = new RealmConfigArgs({
     useCouncilMint: councilMint !== undefined,
-
-    communityMintMaxVoteWeightSource,
     minCommunityTokensToCreateGovernance,
+    communityMintMaxVoteWeightSource,
+    useCommunityVoterWeightAddin: communityVoterWeightAddin !== undefined,
   })
 
   const args = new SetRealmConfigArgs({ configArgs })

--- a/models/registry/api.ts
+++ b/models/registry/api.ts
@@ -2,10 +2,15 @@ import { PublicKey } from '@solana/web3.js'
 import { equalsIgnoreCase } from '../../tools/core/strings'
 import { EndpointTypes } from '../types'
 
+export enum ProgramVersion {
+  V1 = 1,
+  V2,
+}
 export interface RealmInfo {
   symbol: string
   endpoint?: string
   programId: PublicKey
+  programVersion?: ProgramVersion
   realmId: PublicKey
   website?: string
   // Specifies the realm mainnet name for resource lookups

--- a/models/serialisation.ts
+++ b/models/serialisation.ts
@@ -89,6 +89,7 @@ export const GOVERNANCE_SCHEMA = new Map<any, any>([
         ['useCouncilMint', 'u8'],
         ['minCommunityTokensToCreateGovernance', 'u64'],
         ['communityMintMaxVoteWeightSource', MintMaxVoteWeightSource],
+        ['useCommunityVoterWeightAddin', 'u8'],
       ],
     },
   ],

--- a/models/serialisation.ts
+++ b/models/serialisation.ts
@@ -39,10 +39,12 @@ import {
   SignatoryRecord,
   TokenOwnerRecord,
   VoteRecord,
+  RealmConfigAccount,
   VoteThresholdPercentage,
   VoteWeight,
 } from './accounts'
 import { serialize } from 'borsh'
+import { ProgramVersion } from './registry/api'
 
 // Temp. workaround to support u16.
 ;(BinaryReader.prototype as any).readU16 = function () {
@@ -80,412 +82,446 @@ export const serializeInstructionToBase64 = (
   return Buffer.from(serialize(GOVERNANCE_SCHEMA, data)).toString('base64')
 }
 
-export const GOVERNANCE_SCHEMA = new Map<any, any>([
-  [
-    RealmConfigArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['useCouncilMint', 'u8'],
-        ['minCommunityTokensToCreateGovernance', 'u64'],
-        ['communityMintMaxVoteWeightSource', MintMaxVoteWeightSource],
-        ['useCommunityVoterWeightAddin', 'u8'],
-      ],
-    },
-  ],
-  [
-    CreateRealmArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['name', 'string'],
-        ['configArgs', RealmConfigArgs],
-      ],
-    },
-  ],
-  [
-    DepositGoverningTokensArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    WithdrawGoverningTokensArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    CreateAccountGovernanceArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['config', GovernanceConfig],
-      ],
-    },
-  ],
-  [
-    CreateProgramGovernanceArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['config', GovernanceConfig],
-        ['transferUpgradeAuthority', 'u8'],
-      ],
-    },
-  ],
-  [
-    CreateMintGovernanceArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['config', GovernanceConfig],
-        ['transferMintAuthority', 'u8'],
-      ],
-    },
-  ],
-  [
-    CreateTokenGovernanceArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['config', GovernanceConfig],
-        ['transferTokenOwner', 'u8'],
-      ],
-    },
-  ],
-  [
-    SetGovernanceConfigArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['config', GovernanceConfig],
-      ],
-    },
-  ],
-  [
-    CreateProposalArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['name', 'string'],
-        ['descriptionLink', 'string'],
-        ['governingTokenMint', 'pubkey'],
-      ],
-    },
-  ],
-  [
-    AddSignatoryArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['signatory', 'pubkey'],
-      ],
-    },
-  ],
-  [
-    SignOffProposalArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    CancelProposalArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    RelinquishVoteArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    FinalizeVoteArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    CastVoteArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['vote', 'u8'],
-      ],
-    },
-  ],
-  [
-    InsertInstructionArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['index', 'u16'],
-        ['holdUpTime', 'u32'],
-        ['instructionData', InstructionData],
-      ],
-    },
-  ],
-  [
-    RemoveInstructionArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    ExecuteInstructionArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    FlagInstructionErrorArgs,
-    {
-      kind: 'struct',
-      fields: [['instruction', 'u8']],
-    },
-  ],
-  [
-    SetRealmAuthorityArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['newRealmAuthority', { kind: 'option', type: 'pubkey' }],
-      ],
-    },
-  ],
-  [
-    SetRealmConfigArgs,
-    {
-      kind: 'struct',
-      fields: [
-        ['instruction', 'u8'],
-        ['configArgs', RealmConfigArgs],
-      ],
-    },
-  ],
-  [
-    InstructionData,
-    {
-      kind: 'struct',
-      fields: [
-        ['programId', 'pubkey'],
-        ['accounts', [AccountMetaData]],
-        ['data', ['u8']],
-      ],
-    },
-  ],
-  [
-    AccountMetaData,
-    {
-      kind: 'struct',
-      fields: [
-        ['pubkey', 'pubkey'],
-        ['isSigner', 'u8'],
-        ['isWritable', 'u8'],
-      ],
-    },
-  ],
+export const GOVERNANCE_SCHEMA = createGovernanceSchema(ProgramVersion.V1)
+export const GOVERNANCE_SCHEMA_V2 = createGovernanceSchema(ProgramVersion.V2)
 
-  [
-    MintMaxVoteWeightSource,
-    {
-      kind: 'struct',
-      fields: [
-        ['type', 'u8'],
-        ['value', 'u64'],
-      ],
-    },
-  ],
+export function getGovernanceSchema(programVersion: ProgramVersion) {
+  switch (programVersion) {
+    case ProgramVersion.V1:
+      return GOVERNANCE_SCHEMA
+    default:
+      return GOVERNANCE_SCHEMA_V2
+  }
+}
 
-  [
-    RealmConfig,
-    {
-      kind: 'struct',
-      fields: [
-        ['reserved', [8]],
-        ['minCommunityTokensToCreateGovernance', 'u64'],
-        ['communityMintMaxVoteWeightSource', MintMaxVoteWeightSource],
-        ['councilMint', { kind: 'option', type: 'pubkey' }],
-      ],
-    },
-  ],
-  [
-    Realm,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['communityMint', 'pubkey'],
-        ['config', RealmConfig],
-        ['reserved', [8]],
-        ['authority', { kind: 'option', type: 'pubkey' }],
-        ['name', 'string'],
-      ],
-    },
-  ],
-  [
-    Governance,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['realm', 'pubkey'],
-        ['governedAccount', 'pubkey'],
-        ['proposalCount', 'u32'],
-        ['config', GovernanceConfig],
-        ['reserved', [8]],
-      ],
-    },
-  ],
-  [
-    VoteThresholdPercentage,
-    {
-      kind: 'struct',
-      fields: [
-        ['type', 'u8'],
-        ['value', 'u8'],
-      ],
-    },
-  ],
-  [
-    GovernanceConfig,
-    {
-      kind: 'struct',
-      fields: [
-        ['voteThresholdPercentage', VoteThresholdPercentage],
-        ['minCommunityTokensToCreateProposal', 'u64'],
-        ['minInstructionHoldUpTime', 'u32'],
-        ['maxVotingTime', 'u32'],
-        ['voteWeightSource', 'u8'],
-        ['proposalCoolOffTime', 'u32'],
-        ['minCouncilTokensToCreateProposal', 'u64'],
-      ],
-    },
-  ],
-  [
-    TokenOwnerRecord,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['realm', 'pubkey'],
-        ['governingTokenMint', 'pubkey'],
-        ['governingTokenOwner', 'pubkey'],
-        ['governingTokenDepositAmount', 'u64'],
-        ['unrelinquishedVotesCount', 'u32'],
-        ['totalVotesCount', 'u32'],
-        ['reserved', [8]],
-        ['governanceDelegate', { kind: 'option', type: 'pubkey' }],
-      ],
-    },
-  ],
-  [
-    Proposal,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['governance', 'pubkey'],
-        ['governingTokenMint', 'pubkey'],
-        ['state', 'u8'],
-        ['tokenOwnerRecord', 'pubkey'],
-        ['signatoriesCount', 'u8'],
-        ['signatoriesSignedOffCount', 'u8'],
-        ['yesVotesCount', 'u64'],
-        ['noVotesCount', 'u64'],
-        ['instructionsExecutedCount', 'u16'],
-        ['instructionsCount', 'u16'],
-        ['instructionsNextIndex', 'u16'],
-        ['draftAt', 'u64'],
-        ['signingOffAt', { kind: 'option', type: 'u64' }],
-        ['votingAt', { kind: 'option', type: 'u64' }],
-        ['votingAtSlot', { kind: 'option', type: 'u64' }],
-        ['votingCompletedAt', { kind: 'option', type: 'u64' }],
-        ['executingAt', { kind: 'option', type: 'u64' }],
-        ['closedAt', { kind: 'option', type: 'u64' }],
-        ['executionFlags', 'u8'],
-        ['maxVoteWeight', { kind: 'option', type: 'u64' }],
-        [
-          'voteThresholdPercentage',
-          { kind: 'option', type: VoteThresholdPercentage },
+function createGovernanceSchema(programVersion: ProgramVersion) {
+  return new Map<any, any>([
+    [
+      RealmConfigArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['useCouncilMint', 'u8'],
+          ['minCommunityTokensToCreateGovernance', 'u64'],
+          ['communityMintMaxVoteWeightSource', MintMaxVoteWeightSource],
+          // V1 of the program used restrictive instruction deserialisation which didn't allow additional data
+          programVersion > ProgramVersion.V1
+            ? ['useCommunityVoterWeightAddin', 'u8']
+            : undefined,
+        ].filter(Boolean),
+      },
+    ],
+    [
+      CreateRealmArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['name', 'string'],
+          ['configArgs', RealmConfigArgs],
         ],
-        ['name', 'string'],
-        ['descriptionLink', 'string'],
-      ],
-    },
-  ],
-  [
-    SignatoryRecord,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['proposal', 'pubkey'],
-        ['signatory', 'pubkey'],
-        ['signedOff', 'u8'],
-      ],
-    },
-  ],
-  [
-    VoteWeight,
-    {
-      kind: 'enum',
-      values: [
-        ['yes', 'u64'],
-        ['no', 'u64'],
-      ],
-    },
-  ],
-  [
-    VoteRecord,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['proposal', 'pubkey'],
-        ['governingTokenOwner', 'pubkey'],
-        ['isRelinquished', 'u8'],
-        ['voteWeight', VoteWeight],
-      ],
-    },
-  ],
-  [
-    ProposalInstruction,
-    {
-      kind: 'struct',
-      fields: [
-        ['accountType', 'u8'],
-        ['proposal', 'pubkey'],
-        ['instructionIndex', 'u16'],
-        ['holdUpTime', 'u32'],
-        ['instruction', InstructionData],
-        ['executedAt', { kind: 'option', type: 'u64' }],
-        ['executionStatus', 'u8'],
-      ],
-    },
-  ],
-])
+      },
+    ],
+    [
+      DepositGoverningTokensArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          // V1 of the program used restrictive instruction deserialisation which didn't allow additional data
+          programVersion > ProgramVersion.V1 ? ['amount', 'u64'] : undefined,
+        ].filter(Boolean),
+      },
+    ],
+    [
+      WithdrawGoverningTokensArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      CreateAccountGovernanceArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['config', GovernanceConfig],
+        ],
+      },
+    ],
+    [
+      CreateProgramGovernanceArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['config', GovernanceConfig],
+          ['transferUpgradeAuthority', 'u8'],
+        ],
+      },
+    ],
+    [
+      CreateMintGovernanceArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['config', GovernanceConfig],
+          ['transferMintAuthority', 'u8'],
+        ],
+      },
+    ],
+    [
+      CreateTokenGovernanceArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['config', GovernanceConfig],
+          ['transferTokenOwner', 'u8'],
+        ],
+      },
+    ],
+    [
+      SetGovernanceConfigArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['config', GovernanceConfig],
+        ],
+      },
+    ],
+    [
+      CreateProposalArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['name', 'string'],
+          ['descriptionLink', 'string'],
+          ['governingTokenMint', 'pubkey'],
+        ],
+      },
+    ],
+    [
+      AddSignatoryArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['signatory', 'pubkey'],
+        ],
+      },
+    ],
+    [
+      SignOffProposalArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      CancelProposalArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      RelinquishVoteArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      FinalizeVoteArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      CastVoteArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['vote', 'u8'],
+        ],
+      },
+    ],
+    [
+      InsertInstructionArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['index', 'u16'],
+          ['holdUpTime', 'u32'],
+          ['instructionData', InstructionData],
+        ],
+      },
+    ],
+    [
+      RemoveInstructionArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      ExecuteInstructionArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      FlagInstructionErrorArgs,
+      {
+        kind: 'struct',
+        fields: [['instruction', 'u8']],
+      },
+    ],
+    [
+      SetRealmAuthorityArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['newRealmAuthority', { kind: 'option', type: 'pubkey' }],
+        ],
+      },
+    ],
+    [
+      SetRealmConfigArgs,
+      {
+        kind: 'struct',
+        fields: [
+          ['instruction', 'u8'],
+          ['configArgs', RealmConfigArgs],
+        ],
+      },
+    ],
+    [
+      InstructionData,
+      {
+        kind: 'struct',
+        fields: [
+          ['programId', 'pubkey'],
+          ['accounts', [AccountMetaData]],
+          ['data', ['u8']],
+        ],
+      },
+    ],
+    [
+      AccountMetaData,
+      {
+        kind: 'struct',
+        fields: [
+          ['pubkey', 'pubkey'],
+          ['isSigner', 'u8'],
+          ['isWritable', 'u8'],
+        ],
+      },
+    ],
+
+    [
+      MintMaxVoteWeightSource,
+      {
+        kind: 'struct',
+        fields: [
+          ['type', 'u8'],
+          ['value', 'u64'],
+        ],
+      },
+    ],
+
+    [
+      RealmConfig,
+      {
+        kind: 'struct',
+        fields: [
+          ['useCommunityVoterWeightAddin', 'u8'],
+          ['reserved', [7]],
+          ['minCommunityTokensToCreateGovernance', 'u64'],
+          ['communityMintMaxVoteWeightSource', MintMaxVoteWeightSource],
+          ['councilMint', { kind: 'option', type: 'pubkey' }],
+        ],
+      },
+    ],
+    [
+      Realm,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['communityMint', 'pubkey'],
+          ['config', RealmConfig],
+          ['reserved', [8]],
+          ['authority', { kind: 'option', type: 'pubkey' }],
+          ['name', 'string'],
+        ],
+      },
+    ],
+    [
+      RealmConfigAccount,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['realm', 'pubkey'],
+          ['communityVoterWeightAddin', { kind: 'option', type: 'pubkey' }],
+        ],
+      },
+    ],
+    [
+      Governance,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['realm', 'pubkey'],
+          ['governedAccount', 'pubkey'],
+          ['proposalCount', 'u32'],
+          ['config', GovernanceConfig],
+          ['reserved', [8]],
+        ],
+      },
+    ],
+    [
+      VoteThresholdPercentage,
+      {
+        kind: 'struct',
+        fields: [
+          ['type', 'u8'],
+          ['value', 'u8'],
+        ],
+      },
+    ],
+    [
+      GovernanceConfig,
+      {
+        kind: 'struct',
+        fields: [
+          ['voteThresholdPercentage', VoteThresholdPercentage],
+          ['minCommunityTokensToCreateProposal', 'u64'],
+          ['minInstructionHoldUpTime', 'u32'],
+          ['maxVotingTime', 'u32'],
+          ['voteWeightSource', 'u8'],
+          ['proposalCoolOffTime', 'u32'],
+          ['minCouncilTokensToCreateProposal', 'u64'],
+        ],
+      },
+    ],
+    [
+      TokenOwnerRecord,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['realm', 'pubkey'],
+          ['governingTokenMint', 'pubkey'],
+          ['governingTokenOwner', 'pubkey'],
+          ['governingTokenDepositAmount', 'u64'],
+          ['unrelinquishedVotesCount', 'u32'],
+          ['totalVotesCount', 'u32'],
+          ['outstandingProposalCount', 'u8'],
+          ['reserved', [7]],
+          ['governanceDelegate', { kind: 'option', type: 'pubkey' }],
+        ],
+      },
+    ],
+    [
+      Proposal,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['governance', 'pubkey'],
+          ['governingTokenMint', 'pubkey'],
+          ['state', 'u8'],
+          ['tokenOwnerRecord', 'pubkey'],
+          ['signatoriesCount', 'u8'],
+          ['signatoriesSignedOffCount', 'u8'],
+          ['yesVotesCount', 'u64'],
+          ['noVotesCount', 'u64'],
+          ['instructionsExecutedCount', 'u16'],
+          ['instructionsCount', 'u16'],
+          ['instructionsNextIndex', 'u16'],
+          ['draftAt', 'u64'],
+          ['signingOffAt', { kind: 'option', type: 'u64' }],
+          ['votingAt', { kind: 'option', type: 'u64' }],
+          ['votingAtSlot', { kind: 'option', type: 'u64' }],
+          ['votingCompletedAt', { kind: 'option', type: 'u64' }],
+          ['executingAt', { kind: 'option', type: 'u64' }],
+          ['closedAt', { kind: 'option', type: 'u64' }],
+          ['executionFlags', 'u8'],
+          ['maxVoteWeight', { kind: 'option', type: 'u64' }],
+          [
+            'voteThresholdPercentage',
+            { kind: 'option', type: VoteThresholdPercentage },
+          ],
+          ['name', 'string'],
+          ['descriptionLink', 'string'],
+        ],
+      },
+    ],
+    [
+      SignatoryRecord,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['proposal', 'pubkey'],
+          ['signatory', 'pubkey'],
+          ['signedOff', 'u8'],
+        ],
+      },
+    ],
+    [
+      VoteWeight,
+      {
+        kind: 'enum',
+        values: [
+          ['yes', 'u64'],
+          ['no', 'u64'],
+        ],
+      },
+    ],
+    [
+      VoteRecord,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['proposal', 'pubkey'],
+          ['governingTokenOwner', 'pubkey'],
+          ['isRelinquished', 'u8'],
+          ['voteWeight', VoteWeight],
+        ],
+      },
+    ],
+    [
+      ProposalInstruction,
+      {
+        kind: 'struct',
+        fields: [
+          ['accountType', 'u8'],
+          ['proposal', 'pubkey'],
+          ['instructionIndex', 'u16'],
+          ['holdUpTime', 'u32'],
+          ['instruction', InstructionData],
+          ['executedAt', { kind: 'option', type: 'u64' }],
+          ['executionStatus', 'u8'],
+        ],
+      },
+    ],
+  ])
+}
 
 export function getInstructionDataFromBase64(instructionDataBase64: string) {
   const instructionDataBin = Buffer.from(instructionDataBase64, 'base64')

--- a/pages/dao/[symbol]/proposal/new.tsx
+++ b/pages/dao/[symbol]/proposal/new.tsx
@@ -53,6 +53,7 @@ const New = () => {
   const {
     symbol,
     realm,
+    realmInfo,
     realmDisplayName,
     ownVoterWeight,
     mint,
@@ -137,6 +138,7 @@ const New = () => {
 
       const rpcContext = new RpcContext(
         new PublicKey(realm.account.owner.toString()),
+        realmInfo?.programVersion,
         wallet,
         connection.current,
         connection.endpoint

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { PlusIcon } from '@heroicons/react/outline'
 import { getAllRealmInfos, RealmInfo } from '../../models/registry/api'
 // import Input from '../../components/Input'
 // import Button from '../../components/Button'
@@ -21,7 +23,9 @@ const Realms = () => {
   //   const [realmsSearchResults, setSearchResult] = useState([])
   //   const [search, setSearch] = useState('')
   //   const [viewType, setViewType] = useState(ROW)
-  const { actions, selectedRealm, connection } = useWalletStore((s) => s)
+  const { actions, selectedRealm, connected, connection } = useWalletStore(
+    (s) => s
+  )
 
   useEffect(() => {
     if (connection) {
@@ -71,28 +75,39 @@ const Realms = () => {
         {isLoading ? (
           <Loading></Loading>
         ) : (
-          realms.map((realm: RealmInfo) => (
-            <div
-              onClick={() => goToRealm(realm)}
-              className="bg-bkg-2 cursor-pointer default-transition flex flex-col items-center p-8 rounded-lg hover:bg-bkg-3"
-              key={realm.realmId.toString()}
-            >
-              <div className="pb-5">
-                {realm.ogImage ? (
-                  <div className="bg-[rgba(255,255,255,0.06)] rounded-full h-16 w-16 flex items-center justify-center">
-                    <img className="w-10" src={realm.ogImage}></img>
-                  </div>
-                ) : (
-                  <div className="bg-[rgba(255,255,255,0.06)] h-16 w-16 flex font-bold items-center justify-center rounded-full text-fgd-3">
-                    {realm.symbol?.charAt(0)}
-                  </div>
-                )}
+          <>
+            {realms.map((realm: RealmInfo) => (
+              <div
+                onClick={() => goToRealm(realm)}
+                className="bg-bkg-2 cursor-pointer default-transition flex flex-col items-center p-8 rounded-lg hover:bg-bkg-3"
+                key={realm.realmId.toString()}
+              >
+                <div className="pb-5">
+                  {realm.ogImage ? (
+                    <div className="bg-[rgba(255,255,255,0.06)] rounded-full h-16 w-16 flex items-center justify-center">
+                      <img className="w-10" src={realm.ogImage}></img>
+                    </div>
+                  ) : (
+                    <div className="bg-[rgba(255,255,255,0.06)] h-16 w-16 flex font-bold items-center justify-center rounded-full text-fgd-3">
+                      {realm.symbol?.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <h3 className="text-center">
+                  {realm.displayName ?? realm.symbol}
+                </h3>
               </div>
-              <h3 className="text-center">
-                {realm.displayName ?? realm.symbol}
-              </h3>
-            </div>
-          ))
+            ))}
+            {connected && (
+              <Link href={fmtUrlWithCluster(`/realms/new`)}>
+                <div className="bg-bkg-2 p-14 cursor-pointer default-transition flex flex-col items-center justify-center rounded-lg hover:bg-bkg-3">
+                  <div className="bg-[rgba(255,255,255,0.06)] h-16 w-16 flex font-bold items-center justify-center rounded-full text-fgd-3">
+                    <PlusIcon />
+                  </div>
+                </div>
+              </Link>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/pages/realms/new.tsx
+++ b/pages/realms/new.tsx
@@ -4,7 +4,7 @@ import BN from 'bn.js'
 
 import useQueryContext from '@hooks/useQueryContext'
 import Input from '@components/inputs/Input'
-import React, { createContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Button from '@components/Button'
 import { RpcContext } from '@models/core/api'
 import { MintMaxVoteWeightSource } from 'models/accounts'
@@ -15,10 +15,7 @@ import { notify } from 'utils/notifications'
 import * as yup from 'yup'
 import { formValidation, isFormValid } from '@utils/formValidation'
 import { useRouter } from 'next/router'
-import {
-  ComponentInstructionData,
-  InstructionsContext,
-} from '@utils/uiTypes/proposalCreationTypes'
+import { ComponentInstructionData } from '@utils/uiTypes/proposalCreationTypes'
 import useInstructions from '@hooks/useInstructions'
 
 const publicKeyValidationTest = (value) => {
@@ -50,16 +47,6 @@ const schema = yup.object().shape({
     ),
 })
 
-const defaultGovernanceCtx: InstructionsContext = {
-  instructionsData: [],
-  handleSetInstructions: () => null,
-  governance: null,
-  setGovernance: () => null,
-}
-export const NewProposalContext = createContext<InstructionsContext>(
-  defaultGovernanceCtx
-)
-
 const New = () => {
   const router = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
@@ -74,6 +61,7 @@ const New = () => {
     name: '',
     communityTokenMint: '',
     councilMint: '',
+    programVersion: 1,
     communityMintMaxVoteWeightSource: 0.5,
     minCommunityTokensToCreateGovernance: 0.001,
   })
@@ -88,8 +76,6 @@ const New = () => {
     setForm({ ...form, [propertyName]: value })
   }
 
-  console.log(connection)
-
   const handleCreate = async () => {
     if (!connection) return
     setFormErrors({})
@@ -102,6 +88,7 @@ const New = () => {
     if (isValid) {
       const rpcContext = new RpcContext(
         new PublicKey(form.governanceProgramId),
+        form.programVersion,
         wallet,
         connection.current,
         connection.endpoint
@@ -130,7 +117,7 @@ const New = () => {
 
   useEffect(() => {
     setInstructions([instructionsData[0]])
-  }, [instructionsData[0].governedAccount?.token?.publicKey])
+  }, [instructionsData[0]])
 
   return (
     <div
@@ -162,6 +149,22 @@ const New = () => {
                 handleSetForm({
                   value: evt.target.value,
                   propertyName: 'governanceProgramId',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Governance program version"
+              placeholder={1}
+              step="1"
+              value={form.programVersion}
+              type="number"
+              error={formErrors['programVersion']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'programVersion',
                 })
               }
             />

--- a/pages/realms/new.tsx
+++ b/pages/realms/new.tsx
@@ -1,0 +1,256 @@
+import Link from 'next/link'
+import { ArrowLeftIcon } from '@heroicons/react/outline'
+import BN from 'bn.js'
+
+import useQueryContext from '@hooks/useQueryContext'
+import Input from '@components/inputs/Input'
+import React, { createContext, useEffect, useState } from 'react'
+import Button from '@components/Button'
+import { RpcContext } from '@models/core/api'
+import { MintMaxVoteWeightSource } from 'models/accounts'
+import { registerRealm } from 'actions/registerRealm'
+import useWalletStore from 'stores/useWalletStore'
+import { PublicKey } from '@solana/web3.js'
+import { notify } from 'utils/notifications'
+import * as yup from 'yup'
+import { formValidation, isFormValid } from '@utils/formValidation'
+import { useRouter } from 'next/router'
+import {
+  ComponentInstructionData,
+  InstructionsContext,
+} from '@utils/uiTypes/proposalCreationTypes'
+import useInstructions from '@hooks/useInstructions'
+
+const publicKeyValidationTest = (value) => {
+  try {
+    if (!value) return false
+    new PublicKey(value)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+const schema = yup.object().shape({
+  governanceProgramId: yup
+    .string()
+    .required('Governance program id is required')
+    .test(
+      'is-public-key',
+      'Governance program id is not a valid public key',
+      publicKeyValidationTest
+    ),
+  name: yup.string().required('Name is required'),
+  communityTokenMint: yup
+    .string()
+    .required('Community token mint is required')
+    .test(
+      'is-public-key',
+      'Community token mint id is not a valid public key',
+      publicKeyValidationTest
+    ),
+})
+
+const defaultGovernanceCtx: InstructionsContext = {
+  instructionsData: [],
+  handleSetInstructions: () => null,
+  governance: null,
+  setGovernance: () => null,
+}
+export const NewProposalContext = createContext<InstructionsContext>(
+  defaultGovernanceCtx
+)
+
+const New = () => {
+  const router = useRouter()
+  const { fmtUrlWithCluster } = useQueryContext()
+  const { getAvailableInstructions } = useInstructions()
+  const availableInstructions = getAvailableInstructions()
+
+  const wallet = useWalletStore((s) => s.current)
+  const connection = useWalletStore((s) => s.connection)
+
+  const [form, setForm] = useState({
+    governanceProgramId: '',
+    name: '',
+    communityTokenMint: '',
+    councilMint: '',
+    communityMintMaxVoteWeightSource: 0.5,
+    minCommunityTokensToCreateGovernance: 0.001,
+  })
+  const [formErrors, setFormErrors] = useState({})
+  const [instructionsData, setInstructions] = useState<
+    ComponentInstructionData[]
+  >([{ type: availableInstructions[0] }])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSetForm = ({ propertyName, value }) => {
+    setFormErrors({})
+    setForm({ ...form, [propertyName]: value })
+  }
+
+  console.log(connection)
+
+  const handleCreate = async () => {
+    if (!connection) return
+    setFormErrors({})
+    setIsLoading(true)
+    const { isValid, validationErrors }: formValidation = await isFormValid(
+      schema,
+      form
+    )
+
+    if (isValid) {
+      const rpcContext = new RpcContext(
+        new PublicKey(form.governanceProgramId),
+        wallet,
+        connection.current,
+        connection.endpoint
+      )
+
+      try {
+        await registerRealm(
+          rpcContext,
+          form.name,
+          new PublicKey(form.communityTokenMint),
+          form.councilMint ? new PublicKey(form.councilMint) : undefined,
+          MintMaxVoteWeightSource.FULL_SUPPLY_FRACTION,
+          new BN(form.minCommunityTokensToCreateGovernance)
+        )
+        const url = fmtUrlWithCluster(`/realms`)
+        router.push(url)
+      } catch (ex) {
+        console.log(ex)
+        notify({ type: 'error', message: `${ex}` })
+      }
+    } else {
+      setFormErrors(validationErrors)
+    }
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    setInstructions([instructionsData[0]])
+  }, [instructionsData[0].governedAccount?.token?.publicKey])
+
+  return (
+    <div
+      className={`bg-bkg-2 col-span-12 md:col-span-7 md:order-first lg:col-span-8 order-last p-4 md:p-6 rounded-lg space-y-3 ${
+        isLoading ? 'pointer-events-none' : ''
+      }`}
+    >
+      <>
+        <Link href={fmtUrlWithCluster('/realms')}>
+          <a className="flex items-center text-fgd-3 text-sm transition-all hover:text-fgd-1">
+            <ArrowLeftIcon className="h-4 w-4 mr-1 text-primary-light" />
+            Back
+          </a>
+        </Link>
+        <div className="border-b border-fgd-4 pb-4 pt-2">
+          <div className="flex items-center justify-between">
+            <h1>Create a new realm</h1>
+          </div>
+        </div>
+        <div className="pt-2">
+          <div className="pb-4">
+            <Input
+              label="Governance Program Id"
+              placeholder="Id of the governance program this realm will be associated with"
+              value={form.governanceProgramId}
+              type="text"
+              error={formErrors['governanceProgramId']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'governanceProgramId',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Name"
+              placeholder="Name of your realm"
+              value={form.name}
+              type="text"
+              error={formErrors['name']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'name',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Community Mint Id"
+              placeholder="Community mint id of this realm"
+              value={form.communityTokenMint}
+              type="text"
+              error={formErrors['communityTokenMint']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'communityTokenMint',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Council Mint Id"
+              placeholder="(Optional) Council mint"
+              value={form.councilMint}
+              type="text"
+              error={formErrors['councilMint']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'councilMint',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Community mint supply factor (max vote weight)"
+              placeholder="Community mint supply factor (max vote weight)"
+              value={form.communityMintMaxVoteWeightSource}
+              type="number"
+              error={formErrors['communityMintMaxVoteWeightSource']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'communityMintMaxVoteWeightSource',
+                })
+              }
+            />
+          </div>
+          <div className="pb-4">
+            <Input
+              label="Min community tokens to create governance"
+              placeholder="Min community tokens to create governance"
+              step="0.01"
+              value={form.minCommunityTokensToCreateGovernance}
+              type="number"
+              error={formErrors['minCommunityTokensToCreateGovernance']}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'minCommunityTokensToCreateGovernance',
+                })
+              }
+            />
+          </div>
+          <div className="border-t border-fgd-4 flex justify-end mt-6 pt-6 space-x-4">
+            <Button isLoading={isLoading} onClick={() => handleCreate()}>
+              Create Realm
+            </Button>
+          </div>
+        </div>
+      </>
+    </div>
+  )
+}
+
+export default New


### PR DESCRIPTION
hi @mschneider, @SebastianBor 

I was playing around with the UI and figured I could help make this PR that is a bit more silo-ed 

I was seeing that the withCreateRealm wasn't hooked up to an action at all so I decided it would be useful to hook that up for if someone wants to create new realms through this UI since creating the raw instruction is obviously hard manually.

![image](https://user-images.githubusercontent.com/16511084/140571240-04f3bd93-b6b4-41ce-a17e-dcbd8442f0f1.png)
![image](https://user-images.githubusercontent.com/16511084/140571784-531587de-ee76-4bb2-866b-d1b56f07d0e2.png)

I wanted to open a draft to hear thoughts.

I also looked at the other UI example https://github.com/solana-labs/oyster/blob/main/packages/governance/src/models/withCreateRealm.ts#L36 and I see the use of programVersion. Not sure we would want to include that in this version of the UI or if that version is too old now that all new governance program instances wouldnt use it

I needed this functionality to use this UI to create a new realms. It doesnt need to be hooked up to a big button on the realms page if not desired