### PR TITLE
Add env overrides for RPC servers

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,4 @@
 # Run in context of one realm: starts with default realm and disables realms page navigation
 # REALM=MNGO
+MAINNET_RPC=https://mango.rpcpool.com
+DEVNET_RPC=https://mango.devnet.rpcpool.com

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -146,11 +146,11 @@ async function resolveProposalDescription(description: string) {
 export const ENDPOINTS: EndpointInfo[] = [
   {
     name: 'mainnet',
-    url: 'https://mango.rpcpool.com',
+    url: process.env.MAINNET_RPC || 'https://mango.rpcpool.com',
   },
   {
     name: 'devnet',
-    url: 'https://mango.devnet.rpcpool.com',
+    url: process.env.DEVNET_RPC || 'https://mango.devnet.rpcpool.com',
   },
 ]
 


### PR DESCRIPTION
Allow front end hosts to override mango.rpcpool in env file. 