### PR TITLE
Use connection config from the wallet store

### DIFF
--- a/hooks/useHydrateStore.tsx
+++ b/hooks/useHydrateStore.tsx
@@ -1,37 +1,31 @@
-import { Connection } from '@solana/web3.js'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { getRealmInfo } from '../models/registry/api'
 import { EndpointTypes } from '../models/types'
-import useWalletStore, { ENDPOINTS } from '../stores/useWalletStore'
+import useWalletStore from '../stores/useWalletStore'
 
 export default function useHydrateStore() {
   const router = useRouter()
   const { symbol, cluster, pk } = router.query
   const apiEndpoint = cluster ? (cluster as EndpointTypes) : 'mainnet'
   const selectedRealmMints = useWalletStore((s) => s.selectedRealm.mints)
-  const setWalletStore = useWalletStore((s) => s.set)
-  const { fetchAllRealms, fetchRealm, fetchProposal } = useWalletStore(
-    (s) => s.actions
-  )
+  const {
+    fetchAllRealms,
+    fetchRealm,
+    fetchProposal,
+    setConnectionConfig,
+  } = useWalletStore((s) => s.actions)
   useEffect(() => {
     const fetch = async () => {
       const realmInfo = getRealmInfo(symbol as string, apiEndpoint)
+      setConnectionConfig(apiEndpoint)
       if (realmInfo) {
-        setWalletStore((s) => {
-          const ENDPOINT = ENDPOINTS.find((e) => e.name === realmInfo.endpoint)
-          s.connection.cluster = ENDPOINT?.name
-          s.connection.current = ENDPOINT
-            ? new Connection(ENDPOINT.url, 'recent')
-            : undefined
-          s.connection.endpoint = ENDPOINT?.url
-        })
         await fetchAllRealms(realmInfo.programId)
         fetchRealm(realmInfo.programId, realmInfo.realmId)
       }
     }
     fetch()
-  }, [symbol])
+  }, [symbol, cluster])
 
   useEffect(() => {
     const fetch = async () => {

--- a/hooks/useRealm.tsx
+++ b/hooks/useRealm.tsx
@@ -8,8 +8,8 @@ import useWalletStore from '../stores/useWalletStore'
 
 export default function useRealm() {
   const router = useRouter()
-  const { symbol, cluster } = router.query
-  const apiEndpoint = cluster ? (cluster as EndpointTypes) : 'mainnet'
+  const { symbol } = router.query
+  const connection = useWalletStore((s) => s.connection)
   const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletStore((s) => s.current)
   const tokenAccounts = useWalletStore((s) => s.tokenAccounts)
@@ -25,9 +25,11 @@ export default function useRealm() {
     tokenRecords,
     councilTokenOwnerRecords,
   } = useWalletStore((s) => s.selectedRealm)
-  const realmInfo = useMemo(() => getRealmInfo(symbol as string, apiEndpoint), [
-    symbol,
-  ])
+
+  const realmInfo = useMemo(
+    () => getRealmInfo(symbol as string, connection.endpoint as EndpointTypes),
+    [symbol]
+  )
 
   const realmTokenAccount = useMemo(
     () =>

--- a/hooks/useWallet.tsx
+++ b/hooks/useWallet.tsx
@@ -17,7 +17,7 @@ const SECONDS = 1000
 export default function useWallet() {
   const {
     connected,
-    connection: { endpoint },
+    connection,
     current: wallet,
     providerUrl: selectedProviderUrl,
     set: setWalletStore,
@@ -44,7 +44,7 @@ export default function useWallet() {
         // hack to also update wallet synchronously in case it disconnects
         const wallet = new provider.adapter(
           provider.url,
-          endpoint
+          connection.endpoint
         ) as WalletAdapter
         setWalletStore((state) => {
           state.current = wallet
@@ -63,7 +63,7 @@ export default function useWallet() {
         updateWallet()
       }
     }
-  }, [provider, endpoint])
+  }, [provider, connection])
 
   useEffect(() => {
     if (!wallet) return

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -13,25 +13,27 @@ import useQueryContext from '../../hooks/useQueryContext'
 
 const Realms = () => {
   const router = useRouter()
-  const { cluster } = router.query
   const { fmtUrlWithCluster } = useQueryContext()
 
-  const endpoint = cluster ? (cluster as EndpointTypes) : 'mainnet'
   //TODO when we fetch realms data from api add loader handling
   const [isLoading] = useState(false)
   const [realms, setRealms] = useState<RealmInfo[]>([])
   //   const [realmsSearchResults, setSearchResult] = useState([])
   //   const [search, setSearch] = useState('')
   //   const [viewType, setViewType] = useState(ROW)
-  const { actions, selectedRealm } = useWalletStore((s) => s)
+  const { actions, selectedRealm, connection } = useWalletStore((s) => s)
 
   useEffect(() => {
-    const data: RealmInfo[] = getAllRealmInfos(endpoint)
-    setRealms(data)
+    if (connection) {
+      const data: RealmInfo[] = getAllRealmInfos(
+        connection.cluster as EndpointTypes
+      )
+      setRealms(data)
+    }
     if (selectedRealm.realm) {
       actions.deselectRealm()
     }
-  }, [endpoint])
+  }, [connection])
 
   //   useEffect(() => {
   //     const results = realms.filter((realm: RealmInfo) =>

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -152,13 +152,19 @@ export const ENDPOINTS: EndpointInfo[] = [
     name: 'devnet',
     url: process.env.DEVNET_RPC || 'https://mango.devnet.rpcpool.com',
   },
+  {
+    name: 'localnet',
+    url: 'http://127.0.0.1:8899',
+  },
 ]
 
-const ENDPOINT = ENDPOINTS.find((e) => e.name === 'mainnet')
-const INITIAL_CONNECTION_STATE = {
-  cluster: ENDPOINT!.name,
-  current: new Connection(ENDPOINT!.url, 'recent'),
-  endpoint: ENDPOINT!.url,
+function getConnectionConfig(cluster: string) {
+  const ENDPOINT = ENDPOINTS.find((e) => e.name === cluster) || ENDPOINTS[0]
+  return {
+    cluster: ENDPOINT!.name,
+    current: new Connection(ENDPOINT!.url, 'recent'),
+    endpoint: ENDPOINT!.url,
+  }
 }
 
 const INITIAL_REALM_STATE = {
@@ -192,7 +198,7 @@ const INITIAL_PROPOSAL_STATE = {
 
 const useWalletStore = create<WalletStore>((set, get) => ({
   connected: false,
-  connection: INITIAL_CONNECTION_STATE,
+  connection: getConnectionConfig('mainnet'),
   current: undefined,
   realms: {},
   ownVoteRecordsByProposal: {},
@@ -591,6 +597,12 @@ const useWalletStore = create<WalletStore>((set, get) => ({
 
       set((s) => {
         s.selectedProposal.voteRecordsByVoter = voteRecordsByVoter
+      })
+    },
+    async setConnectionConfig(cluster: string) {
+      const set = get().set
+      set((s) => {
+        s.connection = getConnectionConfig(cluster)
       })
     },
   },


### PR DESCRIPTION
Connection is currently set in useWalleStore, but it used separately for fetchRealms

This PR fixes it so the connection in useWalletStore is also used in fetchRealms and it gets set in hydrateStore so the same connection can be used elsewhere and set via the cluster= param.

also added localnet support
