### PR TITLE
Only set connection if it changes https://github.com/blockworks-found…

### DIFF
--- a/hooks/useHydrateStore.tsx
+++ b/hooks/useHydrateStore.tsx
@@ -17,8 +17,8 @@ export default function useHydrateStore() {
   } = useWalletStore((s) => s.actions)
   useEffect(() => {
     const fetch = async () => {
-      const realmInfo = getRealmInfo(symbol as string, apiEndpoint)
       setConnectionConfig(apiEndpoint)
+      const realmInfo = getRealmInfo(symbol as string, apiEndpoint)
       if (realmInfo) {
         await fetchAllRealms(realmInfo.programId)
         fetchRealm(realmInfo.programId, realmInfo.realmId)

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -609,7 +609,9 @@ const useWalletStore = create<WalletStore>((set, get) => ({
     async setConnectionConfig(cluster: string) {
       const set = get().set
       set((s) => {
-        s.connection = getConnectionConfig(cluster)
+        if (s.connection.cluster !== cluster) {
+          s.connection = getConnectionConfig(cluster)
+        }
       })
     },
   },


### PR DESCRIPTION
…ation/governance-ui/issues/83

fixes https://github.com/blockworks-foundation/governance-ui/issues/83

@SebastianBor @abrzezinski94 @dahifi 

since useHydrateStore depended on [cluster] I guess the next router considers cluster changing everytime a page changes so it was recreating a new connection which was disconnecting the wallet. To fix this i put in a check to only re-create connection if it has actually changed. We could put this check inside useHydrateStore but i put it directly in useWalletStore so its more core to the wallet store