### PR TITLE
fix: start notifier immediately (don't wait 5m initially)

### DIFF
--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -107,4 +107,7 @@ async function runNotifier() {
   )
 }
 
+// start notifier immediately
+errorWrapper()
+
 setInterval(errorWrapper, fiveMinutesSeconds * 1000)


### PR DESCRIPTION
Currently, after running `yarn notifier`, nothing will happen for 5 minutes because it waits for the first `setInterval` to fire.

I don't know if this is desired behaviour? If it isn't then this will call the script immediately without the initial 5 minute delay.