### PR TITLE
fix: api rate-limit logic

### DIFF
--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -68,26 +68,24 @@ export async function getGovernanceAccounts<TAccount extends GovernanceAccount>(
     )
   }
 
-  const promises: Promise<Record<string, ParsedAccount<TAccount>>>[] = []
-  // workaround for preventing getting rate limited by public node
-  // 1/ for of instead of map +
-  // 2/ sleep a bit
+  let accounts: Record<string, ParsedAccount<TAccount>> = {}
+
   for (const at of accountTypes) {
-    await new Promise((r) => setTimeout(r, 3000))
-    promises.push(
-      getGovernanceAccountsImpl<TAccount>(
+    accounts = {
+      ...accounts,
+      ...(await getGovernanceAccountsImpl(
         programId,
         endpoint,
         accountClass,
         at,
         filters
-      )
-    )
+      )),
+    }
+    // XXX: sleep to prevent public RPC rate limits
+    await new Promise((r) => setTimeout(r, 3_000))
   }
 
-  const all = await Promise.all(promises)
-
-  return all.reduce((res, r) => ({ ...res, ...r }), {})
+  return accounts
 }
 
 async function getGovernanceAccountsImpl<TAccount extends GovernanceAccount>(


### PR DESCRIPTION
fixes #103

This removes rate limit warnings from the public RPC (so accounts don't get missed when running notifier)

```
❯ yarn notifier
yarn run v1.22.17
$ TS_NODE_PROJECT=./tsconfig.commonjs.json ts-node scripts/governance-notifier.ts
- scanning all proposals
-- countJustOpenedForVoting: 0, countVotingNotStartedYet: 20, countClosed: 45
```

A higher sleep value might also work, idk which is preferable 🤷‍♂️ 