### PR TITLE
remove rate limits from api

### DIFF
--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -68,13 +68,8 @@ export async function getGovernanceAccounts<TAccount extends GovernanceAccount>(
     )
   }
 
-  const promises: Promise<Record<string, ParsedAccount<TAccount>>>[] = []
-  // workaround for preventing getting rate limited by public node
-  // 1/ for of instead of map +
-  // 2/ sleep a bit
-  for (const at of accountTypes) {
-    await new Promise((r) => setTimeout(r, 3000))
-    promises.push(
+  const all = await Promise.all(
+    accountTypes.map((at) =>
       getGovernanceAccountsImpl<TAccount>(
         programId,
         endpoint,
@@ -83,9 +78,7 @@ export async function getGovernanceAccounts<TAccount extends GovernanceAccount>(
         filters
       )
     )
-  }
-
-  const all = await Promise.all(promises)
+  )
 
   return all.reduce((res, r) => ({ ...res, ...r }), {})
 }
@@ -109,7 +102,7 @@ async function getGovernanceAccountsImpl<TAccount extends GovernanceAccount>(
       params: [
         programId.toBase58(),
         {
-          commitment: 'single',
+          commitment: 'processed',
           encoding: 'base64',
           filters: [
             {

--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -20,7 +20,8 @@ function errorWrapper() {
 async function runNotifier() {
   const nowInSeconds = new Date().getTime() / 1000
 
-  const MAINNET_RPC_NODE = 'https://api.mainnet-beta.solana.com'
+  const MAINNET_RPC_NODE =
+    process.env.RPC_URL || 'https://api.mainnet-beta.solana.com'
 
   const realmInfo = getRealmInfo('MNGO')
 


### PR DESCRIPTION
related #104 

An alternative to #103 which removes rate limits from the API and runs requests in parallel.

This will fail using public RPC infra due to rate-limiting, but runs in about 2-3s, rather than #103's ~15s, when using my own RPC provided via an env var i.e.

```
RPC_URL=$RPC yarn notifier
```