### PR TITLE
refactor: move realm data to external JSON

### DIFF
--- a/models/registry/api.ts
+++ b/models/registry/api.ts
@@ -37,14 +37,11 @@ const MAINNET_REALMS = parseRealms(mainnetBetaRealms)
 const DEVNET_REALMS = parseRealms(devnetRealms)
 
 function parseRealms(realms: RealmInfoAsJSON[]) {
-  return realms.map(
-    (realm) =>
-      ({
-        ...realm,
-        programId: new PublicKey(realm.programId),
-        realmId: new PublicKey(realm.realmId),
-      } as RealmInfo)
-  )
+  return realms.map((realm) => ({
+    ...realm,
+    programId: new PublicKey(realm.programId),
+    realmId: new PublicKey(realm.realmId),
+  })) as ReadonlyArray<RealmInfo>
 }
 
 export function getAllRealmInfos({ cluster }: ConnectionContext) {

--- a/models/registry/api.ts
+++ b/models/registry/api.ts
@@ -1,4 +1,6 @@
 import { PublicKey } from '@solana/web3.js'
+import devnetRealms from 'public/realms/devnet.json'
+import mainnetBetaRealms from 'public/realms/mainnet-beta.json'
 import { ConnectionContext } from 'stores/useWalletStore'
 import { equalsIgnoreCase } from '../../tools/core/strings'
 
@@ -6,6 +8,7 @@ export enum ProgramVersion {
   V1 = 1,
   V2,
 }
+
 export interface RealmInfo {
   symbol: string
   programId: PublicKey
@@ -23,245 +26,26 @@ export interface RealmInfo {
   ogImage?: string
 }
 
-// Hardcoded list of mainnet realms
-// TODO: Once governance program clones registry program and governance accounts metadata is on-chain the list should be moved there
-const MAINNET_REALMS: RealmInfo[] = [
-  {
-    symbol: 'MNGO',
-    displayName: 'Mango DAO',
-    programId: new PublicKey('GqTPL6qRf5aUuqscLh8Rg2HTxPUXfhhAXDptTLhp1t2J'),
-    realmId: new PublicKey('DPiH3H3c7t47BMxqTxLsuPQpEC6Kne8GA9VXbxpnZxFE'),
-    website: 'https://mango.markets',
-    keywords:
-      'Mango Markets, REALM, Governance, Serum, SRM, Serum DEX, DEFI, Decentralized Finance, Decentralised Finance, Crypto, ERC20, Ethereum, Decentralize, Solana, SOL, SPL, Cross-Chain, Trading, Fastest, Fast, SerumBTC, SerumUSD, SRM Tokens, SPL Tokens',
-    twitter: '@mangomarkets',
-    ogImage: 'https://trade.mango.markets/assets/icons/logo.svg',
-  },
+interface RealmInfoAsJSON extends Omit<RealmInfo, 'programId' | 'realmId'> {
+  programId: string
+  realmId: string
+}
 
-  {
-    symbol: 'SOCEAN',
-    programId: new PublicKey('5hAykmD4YGcQ7Am3N7nC9kyELq6CThAkU82nhNKDJiCy'),
-    realmId: new PublicKey('759qyfKDMMuo9v36tW7fbGanL63mZFPNbhU7zjPrkuGK'),
-    website: 'https://www.socean.fi',
-    ogImage:
-      'https://socean-git-enhancement-orca-price-feed-lieuzhenghong.vercel.app/static/media/socnRound.c466b499.png',
-  },
-  {
-    symbol: 'Governance',
-    displayName: 'Governance',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('FMEWULPSGR1BKVJK4K7xTjhG23NfYxeAn2bamYgNoUck'),
-  },
-  {
-    symbol: 'Yield Farming',
-    displayName: 'Yield Farming',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('8eUUtRpBCg7sJ5FXfPUMiwSQNqC3FjFLkmS2oFPKoiBi'),
-  },
-  {
-    symbol: 'SCTF1',
-    programId: new PublicKey('gSF1T5PdLc2EutzwAyeExvdW27ySDtFp88ri5Aymah6'),
-    realmId: new PublicKey('EtZWAeFFRC5k6uesap1F1gkHFimsL2HqttVTNAeN86o8'),
-    ogImage: '/realms/SCTF1/img/sctf1.svg',
-  },
-  {
-    symbol: 'SERUM',
-    programId: new PublicKey('AVoAYTs36yB5izAaBkxRG67wL1AMwG3vo41hKtUSb8is'),
-    realmId: new PublicKey('3MMDxjv1SzEFQDKryT7csAvaydYtrgMAc3L9xL9CVLCg'),
-    website: 'https://www.projectserum.com/',
-    ogImage:
-      'https://assets.website-files.com/61284dcff241c2f0729af9f3/61285237ce2e301255d09108_logo-serum.png',
-  },
-  {
-    symbol: 'OMH',
-    displayName: 'Off My Head',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('4SsH1eg4zzwfRXBJjrKTY163U2UvW7n16B35pZVPxRpX'),
-    ogImage: 'https://offmyhead.vercel.app/coin.png',
-    website: 'https://offmyhead.vercel.app',
-    twitter: '@nft_omh',
-  },
-  {
-    symbol: 'FRIES',
-    displayName: 'Soltato',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('7wsrKBeTpqfcribDo34qr8rdSbqXbmQq9Fog2cVirK6C'),
-    ogImage:
-      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FriCEbw1V99GwrJRXPnSQ6su2TabHabNxiZ3VNsVFPPN/logo.png',
-    website: 'https://soltato.io',
-    twitter: '@Soltato_NFT',
-  },
-  {
-    symbol: 'Metaplex Foundation',
-    displayName: 'Metaplex Foundation',
-    programId: new PublicKey('GmtpXy362L8cZfkRmTZMYunWVe8TyRjX5B7sodPZ63LJ'),
-    realmId: new PublicKey('2sEcHwzsNBwNoTM1yAXjtF1HTMQKUAXf8ivtdpSpo9Fv'),
-    ogImage: '/realms/metaplex/img/meta-white.png',
-    website: 'https://metaplex.com',
-    twitter: '@metaplex',
-  },
-  {
-    symbol: 'Metaplex Genesis',
-    displayName: 'Metaplex Genesis',
-    programId: new PublicKey('GMpXgTSJt2nJ7zjD1RwbT2QyPhKqD2MjAZuEaLsfPYLF'),
-    realmId: new PublicKey('Cdui9Va8XnKVng3VGZXcfBFF6XSxbqSi2XruMc7iu817'),
-    ogImage: '/realms/metaplex/img/meta-white.png',
-    website: 'https://metaplex.com',
-    twitter: '@metaplex',
-  },
-  {
-    symbol: '21DAO',
-    displayName: '21DAO',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('Dn5yLFi6ZNhkD25CX4c8qq1MV3CC2vcrH2Qujfzy22rT'),
-    ogImage: '/realms/21DAO/img/21dao_icon.png',
-    website: 'https://21dao.xyz',
-  },
-  {
-    symbol: 'CDNL',
-    displayName: 'Cardinal',
-    programId: new PublicKey('bqTjmeob6XTdfh12px2fZq4aJMpfSY1R1nHZ44VgVZD'),
-    realmId: new PublicKey('8o1tcKzRsEFAWYzi7Ge2cyotCaQW6vt5f2dy2HkWmemg'),
-    ogImage: 'https://app.cardinalconsensus.io/assets/logo-colored.png',
-    website: 'https://www.cardinalconsensus.io',
-    twitter: '@cardinal_dao',
-  },
-  {
-    symbol: 'gSAIL',
-    displayName: 'GSAIL GOVERNANCE DAO',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('36fZRsuM3oXvb5VrEXXVmokbGnjADzVgKpW1pgQq7jXJ'),
-    ogImage:
-      'https://raw.githubusercontent.com/solanasail/token-list/main/assets/mainnet/Gsai2KN28MTGcSZ1gKYFswUpFpS7EM9mvdR9c8f6iVXJ/logo.png',
-    website: 'https://www.solanasail.com/',
-    twitter: '@SolanaSail',
-  },
-  {
-    symbol: 'FAFD',
-    displayName: 'Friends and Family DAO',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('371PRJu9vyU2U6WHcqorakWvz3wpfGSVhHr65BBSoaiN'),
-    ogImage: '/realms/fafd/img/fafd.png',
-    website:
-      'https://find-and-update.company-information.service.gov.uk/company/13753949',
-  },
-  {
-    symbol: '$HOPE',
-    displayName: 'The Sanctuary',
-    programId: new PublicKey('Ghope52FuF6HU3AAhJuAAyS2fiqbVhkAotb7YprL5tdS'),
-    realmId: new PublicKey('CS3HBXBdZ44g7FdZfgPAz6nSBe4FSThg6ANuVdowTT6G'),
-    ogImage: '/realms/hope/img/hope_logo.svg',
-    website: 'https://www.solsanctuary.io',
-  },
+// TODO: Once governance program clones registry program and governance
+//       accounts metadata is on-chain the list should be moved there
+const MAINNET_REALMS = parseRealms(mainnetBetaRealms)
+const DEVNET_REALMS = parseRealms(devnetRealms)
 
-  {
-    symbol: 'FANT',
-    displayName: 'Phantasia',
-    programId: new PublicKey('5sGZEdn32y8nHax7TxEyoHuPS3UXfPWtisgm8kqxat8H'),
-    realmId: new PublicKey('4BNkheiMATVVcyJnGpjPbbPvFuKMx3cCDmkEbtnTz2iV'),
-    ogImage:
-      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FANTafPFBAt93BNJVpdu25pGPmca3RfwdsDsRrT3LX1r/logo.png',
-    website: 'https://phantasia.app',
-    twitter: '@PhantasiaSports',
-  },
-  {
-    symbol: 'MOOD',
-    displayName: 'Strangemood Foundation',
-    programId: new PublicKey('smfjietFKFJ4Sbw1cqESBTpPhF4CwbMwN8kBEC1e5ui'),
-    realmId: new PublicKey('FvzZFjf3NPTZbKAmQA4Gf1v7uTW7HFcP5Pcr2oVm49t3'),
-    ogImage: '/realms/strangemood/img/logo.svg',
-    website: 'https://strangemood.org',
-  },
-]
-
-// Hardcoded list of devnet realms
-const DEVNET_REALMS: RealmInfo[] = [
-  {
-    symbol: 'MNGO',
-    displayName: 'Mango DAO',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('H2iny4dUP2ngt9p4niUWVX4TKvr1h9eSWGNdP1zvwzNQ'),
-    website: 'https://mango.markets',
-    keywords:
-      'Mango Markets, REALM, Governance, Serum, SRM, Serum DEX, DEFI, Decentralized Finance, Decentralised Finance, Crypto, ERC20, Ethereum, Decentralize, Solana, SOL, SPL, Cross-Chain, Trading, Fastest, Fast, SerumBTC, SerumUSD, SRM Tokens, SPL Tokens',
-    twitter: '@mangomarkets',
-    ogImage: 'https://trade.mango.markets/assets/icons/logo.svg',
-  },
-  {
-    symbol: 'SOCEAN',
-    programId: new PublicKey('GSCN8n6XUGqPqoeubY5GM6e3JgtXbzTcpCUREQ1dVXFG'),
-    realmId: new PublicKey('4Z6bAwcBkDg8We6rRdnqK9rjsJz3aMqXAZkpoBZ3hxus'),
-    website: 'https://www.socean.fi',
-    ogImage:
-      'https://socean-git-enhancement-orca-price-feed-lieuzhenghong.vercel.app/static/media/socnRound.c466b499.png',
-  },
-  {
-    symbol: 'Governance',
-    displayName: 'Governance',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('FMEWULPSGR1BKVJK4K7xTjhG23NfYxeAn2bamYgNoUck'),
-  },
-  {
-    symbol: 'Hype-realm',
-    displayName: 'Hype-realm',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('Ap2qT88wk4CPENAcdZN6Q356mauZym4yrQptGXD2AqVF'),
-  },
-  {
-    symbol: 'Realm-8TitF',
-    displayName: 'Realm-8TitF',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('22XYhMSGmPv2nHC3AwbDAP9akyd3rfVRUZt6HUd3wcY5'),
-  },
-  {
-    symbol: 'OMH',
-    displayName: 'Off My Head',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('4SsH1eg4zzwfRXBJjrKTY163U2UvW7n16B35pZVPxRpX'),
-    ogImage: 'https://offmyhead.vercel.app/coin.png',
-    website: 'https://offmyhead.vercel.app',
-    twitter: '@nft_omh',
-  },
-  {
-    symbol: 'NEWDAO',
-    displayName: 'NEWDAO',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('5eZA8mX9pVXzgbA8oES1ismVSAAgsHkEipJbxvsVYb5d'),
-  },
-  {
-    symbol: 'CDNL',
-    displayName: 'Cardinal',
-    programId: new PublicKey('bqTjmeob6XTdfh12px2fZq4aJMpfSY1R1nHZ44VgVZD'),
-    realmId: new PublicKey('8o1tcKzRsEFAWYzi7Ge2cyotCaQW6vt5f2dy2HkWmemg'),
-    ogImage: 'https://app.cardinalconsensus.io/assets/logo-colored.png',
-    website: 'https://www.cardinalconsensus.io',
-    twitter: '@cardinal_dao',
-  },
-  {
-    symbol: 'testgm',
-    displayName: 'testgm',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('5jdLxZkUQLVWwe8mtR9fURFLUFyT6npjiSKzowaqyCj9'),
-  },
-  {
-    symbol: 'RealM_Tuto_1',
-    displayName: 'RealM_Tuto_1',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('756iwQL9tAdTr1mDGiu4P9zWW8FzMY1K6MUXHqkwp9Nc'),
-  },
-  {
-    symbol: 'SAIA',
-    displayName: 'SAIAdao Devnet',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('2VckEenCkkRSRik2ZpNkJN9YjcZke91nbCajYkgP5M9o'),
-  },
-  {
-    symbol: 'Realm-4LbqG',
-    displayName: 'Dev Maximilian',
-    programId: new PublicKey('GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'),
-    realmId: new PublicKey('G25whFStzVjoahyiXiy7rx2G266ePaMpN4yCtMuMKDhJ'),
-  },
-]
+function parseRealms(realms: RealmInfoAsJSON[]) {
+  return realms.map(
+    (realm) =>
+      ({
+        ...realm,
+        programId: new PublicKey(realm.programId),
+        realmId: new PublicKey(realm.realmId),
+      } as RealmInfo)
+  )
+}
 
 export function getAllRealmInfos({ cluster }: ConnectionContext) {
   return cluster === 'mainnet' ? MAINNET_REALMS : DEVNET_REALMS

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -18,7 +18,7 @@ const Realms = () => {
 
   //TODO when we fetch realms data from api add loader handling
   const [isLoading] = useState(false)
-  const [realms, setRealms] = useState<RealmInfo[]>([])
+  const [realms, setRealms] = useState<ReadonlyArray<RealmInfo>>([])
   //   const [realmsSearchResults, setSearchResult] = useState([])
   //   const [search, setSearch] = useState('')
   //   const [viewType, setViewType] = useState(ROW)
@@ -28,7 +28,7 @@ const Realms = () => {
 
   useMemo(async () => {
     if (connection) {
-      const data: RealmInfo[] = await getAllRealmInfos(connection)
+      const data = await getAllRealmInfos(connection)
       setRealms(data)
     }
     if (selectedRealm.realm) {

--- a/public/realms/devnet.json
+++ b/public/realms/devnet.json
@@ -1,0 +1,85 @@
+[
+  {
+    "symbol": "MNGO",
+    "displayName": "Mango DAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "H2iny4dUP2ngt9p4niUWVX4TKvr1h9eSWGNdP1zvwzNQ",
+    "website": "https://mango.markets",
+    "keywords": "Mango Markets, REALM, Governance, Serum, SRM, Serum DEX, DEFI, Decentralized Finance, Decentralised Finance, Crypto, ERC20, Ethereum, Decentralize, Solana, SOL, SPL, Cross-Chain, Trading, Fastest, Fast, SerumBTC, SerumUSD, SRM Tokens, SPL Tokens",
+    "twitter": "@mangomarkets",
+    "ogImage": "https://trade.mango.markets/assets/icons/logo.svg"
+  },
+  {
+    "symbol": "SOCEAN",
+    "programId": "GSCN8n6XUGqPqoeubY5GM6e3JgtXbzTcpCUREQ1dVXFG",
+    "realmId": "4Z6bAwcBkDg8We6rRdnqK9rjsJz3aMqXAZkpoBZ3hxus",
+    "website": "https://www.socean.fi",
+    "ogImage": "https://socean-git-enhancement-orca-price-feed-lieuzhenghong.vercel.app/static/media/socnRound.c466b499.png"
+  },
+  {
+    "symbol": "Governance",
+    "displayName": "Governance",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "FMEWULPSGR1BKVJK4K7xTjhG23NfYxeAn2bamYgNoUck"
+  },
+  {
+    "symbol": "Hype-realm",
+    "displayName": "Hype-realm",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "Ap2qT88wk4CPENAcdZN6Q356mauZym4yrQptGXD2AqVF"
+  },
+  {
+    "symbol": "Realm-8TitF",
+    "displayName": "Realm-8TitF",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "22XYhMSGmPv2nHC3AwbDAP9akyd3rfVRUZt6HUd3wcY5"
+  },
+  {
+    "symbol": "OMH",
+    "displayName": "Off My Head",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "4SsH1eg4zzwfRXBJjrKTY163U2UvW7n16B35pZVPxRpX",
+    "ogImage": "https://offmyhead.vercel.app/coin.png",
+    "website": "https://offmyhead.vercel.app",
+    "twitter": "@nft_omh"
+  },
+  {
+    "symbol": "NEWDAO",
+    "displayName": "NEWDAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "5eZA8mX9pVXzgbA8oES1ismVSAAgsHkEipJbxvsVYb5d"
+  },
+  {
+    "symbol": "CDNL",
+    "displayName": "Cardinal",
+    "programId": "bqTjmeob6XTdfh12px2fZq4aJMpfSY1R1nHZ44VgVZD",
+    "realmId": "8o1tcKzRsEFAWYzi7Ge2cyotCaQW6vt5f2dy2HkWmemg",
+    "ogImage": "https://app.cardinalconsensus.io/assets/logo-colored.png",
+    "website": "https://www.cardinalconsensus.io",
+    "twitter": "@cardinal_dao"
+  },
+  {
+    "symbol": "testgm",
+    "displayName": "testgm",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "5jdLxZkUQLVWwe8mtR9fURFLUFyT6npjiSKzowaqyCj9"
+  },
+  {
+    "symbol": "RealM_Tuto_1",
+    "displayName": "RealM_Tuto_1",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "756iwQL9tAdTr1mDGiu4P9zWW8FzMY1K6MUXHqkwp9Nc"
+  },
+  {
+    "symbol": "SAIA",
+    "displayName": "SAIAdao Devnet",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "2VckEenCkkRSRik2ZpNkJN9YjcZke91nbCajYkgP5M9o"
+  },
+  {
+    "symbol": "Realm-4LbqG",
+    "displayName": "Dev Maximilian",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "G25whFStzVjoahyiXiy7rx2G266ePaMpN4yCtMuMKDhJ"
+  }
+]

--- a/public/realms/mainnet-beta.json
+++ b/public/realms/mainnet-beta.json
@@ -1,0 +1,139 @@
+[
+  {
+    "symbol": "MNGO",
+    "displayName": "Mango DAO",
+    "programId": "GqTPL6qRf5aUuqscLh8Rg2HTxPUXfhhAXDptTLhp1t2J",
+    "realmId": "DPiH3H3c7t47BMxqTxLsuPQpEC6Kne8GA9VXbxpnZxFE",
+    "website": "https://mango.markets",
+    "keywords": "Mango Markets, REALM, Governance, Serum, SRM, Serum DEX, DEFI, Decentralized Finance, Decentralised Finance, Crypto, ERC20, Ethereum, Decentralize, Solana, SOL, SPL, Cross-Chain, Trading, Fastest, Fast, SerumBTC, SerumUSD, SRM Tokens, SPL Tokens",
+    "twitter": "@mangomarkets",
+    "ogImage": "https://trade.mango.markets/assets/icons/logo.svg"
+  },
+  {
+    "symbol": "SOCEAN",
+    "programId": "5hAykmD4YGcQ7Am3N7nC9kyELq6CThAkU82nhNKDJiCy",
+    "realmId": "759qyfKDMMuo9v36tW7fbGanL63mZFPNbhU7zjPrkuGK",
+    "website": "https://www.socean.fi",
+    "ogImage": "https://socean-git-enhancement-orca-price-feed-lieuzhenghong.vercel.app/static/media/socnRound.c466b499.png"
+  },
+  {
+    "symbol": "Governance",
+    "displayName": "Governance",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "FMEWULPSGR1BKVJK4K7xTjhG23NfYxeAn2bamYgNoUck"
+  },
+  {
+    "symbol": "Yield Farming",
+    "displayName": "Yield Farming",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "8eUUtRpBCg7sJ5FXfPUMiwSQNqC3FjFLkmS2oFPKoiBi"
+  },
+  {
+    "symbol": "SCTF1",
+    "programId": "gSF1T5PdLc2EutzwAyeExvdW27ySDtFp88ri5Aymah6",
+    "realmId": "EtZWAeFFRC5k6uesap1F1gkHFimsL2HqttVTNAeN86o8",
+    "ogImage": "/realms/SCTF1/img/sctf1.svg"
+  },
+  {
+    "symbol": "SERUM",
+    "programId": "AVoAYTs36yB5izAaBkxRG67wL1AMwG3vo41hKtUSb8is",
+    "realmId": "3MMDxjv1SzEFQDKryT7csAvaydYtrgMAc3L9xL9CVLCg",
+    "website": "https://www.projectserum.com/",
+    "ogImage": "https://assets.website-files.com/61284dcff241c2f0729af9f3/61285237ce2e301255d09108_logo-serum.png"
+  },
+  {
+    "symbol": "OMH",
+    "displayName": "Off My Head",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "4SsH1eg4zzwfRXBJjrKTY163U2UvW7n16B35pZVPxRpX",
+    "ogImage": "https://offmyhead.vercel.app/coin.png",
+    "website": "https://offmyhead.vercel.app",
+    "twitter": "@nft_omh"
+  },
+  {
+    "symbol": "FRIES",
+    "displayName": "Soltato",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "7wsrKBeTpqfcribDo34qr8rdSbqXbmQq9Fog2cVirK6C",
+    "ogImage": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FriCEbw1V99GwrJRXPnSQ6su2TabHabNxiZ3VNsVFPPN/logo.png",
+    "website": "https://soltato.io",
+    "twitter": "@Soltato_NFT"
+  },
+  {
+    "symbol": "Metaplex Foundation",
+    "displayName": "Metaplex Foundation",
+    "programId": "GmtpXy362L8cZfkRmTZMYunWVe8TyRjX5B7sodPZ63LJ",
+    "realmId": "2sEcHwzsNBwNoTM1yAXjtF1HTMQKUAXf8ivtdpSpo9Fv",
+    "ogImage": "/realms/metaplex/img/meta-white.png",
+    "website": "https://metaplex.com",
+    "twitter": "@metaplex"
+  },
+  {
+    "symbol": "Metaplex Genesis",
+    "displayName": "Metaplex Genesis",
+    "programId": "GMpXgTSJt2nJ7zjD1RwbT2QyPhKqD2MjAZuEaLsfPYLF",
+    "realmId": "Cdui9Va8XnKVng3VGZXcfBFF6XSxbqSi2XruMc7iu817",
+    "ogImage": "/realms/metaplex/img/meta-white.png",
+    "website": "https://metaplex.com",
+    "twitter": "@metaplex"
+  },
+  {
+    "symbol": "21DAO",
+    "displayName": "21DAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "Dn5yLFi6ZNhkD25CX4c8qq1MV3CC2vcrH2Qujfzy22rT",
+    "ogImage": "/realms/21DAO/img/21dao_icon.png",
+    "website": "https://21dao.xyz"
+  },
+  {
+    "symbol": "CDNL",
+    "displayName": "Cardinal",
+    "programId": "bqTjmeob6XTdfh12px2fZq4aJMpfSY1R1nHZ44VgVZD",
+    "realmId": "8o1tcKzRsEFAWYzi7Ge2cyotCaQW6vt5f2dy2HkWmemg",
+    "ogImage": "https://app.cardinalconsensus.io/assets/logo-colored.png",
+    "website": "https://www.cardinalconsensus.io",
+    "twitter": "@cardinal_dao"
+  },
+  {
+    "symbol": "gSAIL",
+    "displayName": "GSAIL GOVERNANCE DAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "36fZRsuM3oXvb5VrEXXVmokbGnjADzVgKpW1pgQq7jXJ",
+    "ogImage": "https://raw.githubusercontent.com/solanasail/token-list/main/assets/mainnet/Gsai2KN28MTGcSZ1gKYFswUpFpS7EM9mvdR9c8f6iVXJ/logo.png",
+    "website": "https://www.solanasail.com/",
+    "twitter": "@SolanaSail"
+  },
+  {
+    "symbol": "FAFD",
+    "displayName": "Friends and Family DAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "371PRJu9vyU2U6WHcqorakWvz3wpfGSVhHr65BBSoaiN",
+    "ogImage": "/realms/fafd/img/fafd.png",
+    "website": "https://find-and-update.company-information.service.gov.uk/company/13753949"
+  },
+  {
+    "symbol": "$HOPE",
+    "displayName": "The Sanctuary",
+    "programId": "Ghope52FuF6HU3AAhJuAAyS2fiqbVhkAotb7YprL5tdS",
+    "realmId": "CS3HBXBdZ44g7FdZfgPAz6nSBe4FSThg6ANuVdowTT6G",
+    "ogImage": "/realms/hope/img/hope_logo.svg",
+    "website": "https://www.solsanctuary.io"
+  },
+  {
+    "symbol": "FANT",
+    "displayName": "Phantasia",
+    "programId": "5sGZEdn32y8nHax7TxEyoHuPS3UXfPWtisgm8kqxat8H",
+    "realmId": "4BNkheiMATVVcyJnGpjPbbPvFuKMx3cCDmkEbtnTz2iV",
+    "ogImage": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FANTafPFBAt93BNJVpdu25pGPmca3RfwdsDsRrT3LX1r/logo.png",
+    "website": "https://phantasia.app",
+    "twitter": "@PhantasiaSports"
+  },
+  {
+    "symbol": "MOOD",
+    "displayName": "Strangemood Foundation",
+    "programId": "smfjietFKFJ4Sbw1cqESBTpPhF4CwbMwN8kBEC1e5ui",
+    "realmId": "FvzZFjf3NPTZbKAmQA4Gf1v7uTW7HFcP5Pcr2oVm49t3",
+    "ogImage": "/realms/strangemood/img/logo.svg",
+    "website": "https://strangemood.org"
+  }
+]


### PR DESCRIPTION
_I know the plan is to get all the realm metadata on chain_ but in the meantime I think that moving it out of the code and into external JSON file(s)  à la [solana tokenlist](https://raw.githack.com/solana-labs/token-list/main/src/tokens/solana.tokenlist.json) could be useful for this project. If you don't agree, no worries :)

It enables a couple of things -

- external projects will be able to fetch a list of DAOs until the metadata is stored on chain, this would be particularly useful for notifications stuff that I am working on
- contributors can add their DAO without needing to go into code and potentially create conflicts with open feature branches or accidentally break something

## Considerations

### Images

Images aren't currently absolute URLs, they probably should be if this was merged as people might pull a versioned github URL rather than something like https://dao-beta.mango.markets/realms/mainnet-beta.json

### mainnet vs mainnet-beta?

I noticed the project has chosen to use `mainnet` over `mainnet-beta`, and its own cluster type `export type EndpointTypes = 'mainnet' | 'devnet' | 'localnet'` rather than using or extending `export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta'` provided by web3.js, is there a reason for that? I'm happy to use mainnet on this project going forward if that's the preferred nomenclature

### Versioning

There's no versioning in this JSON, I just left it as a simple array to try and minimise that changes I was making here, but maybe it should have something as a root object key? e.g.

```json
{
  "version": 1,
  "realms": [
  ]
}
```

I'd also be a fan of having the realms as an object with the realmId as the key to enforce uniqueness -
```json
{
  "DPiH3H3c7t47BMxqTxLsuPQpEC6Kne8GA9VXbxpnZxFE": {
    "symbol": "MNGO",
    "displayName": "Mango DAO",
    "programId": "GqTPL6qRf5aUuqscLh8Rg2HTxPUXfhhAXDptTLhp1t2J",
  },
  "759qyfKDMMuo9v36tW7fbGanL63mZFPNbhU7zjPrkuGK": {
    "symbol": "SOCEAN",
    "programId": "5hAykmD4YGcQ7Am3N7nC9kyELq6CThAkU82nhNKDJiCy"
  }
}
```

but I understand if that's not a popular choice

### Separate files

I also split `mainnet-beta` realms and `devnet` into separate JSON files, I've never really understood why the [solana tokenlist](https://raw.githack.com/solana-labs/token-list/main/src/tokens/solana.tokenlist.json) has collated everything into a single file? _update: on reflection I guess it's to share tags etc, but it idk about the trade-off?_

I suspect the majority of devs would want to fetch all the DAOs for a single chain, but maybe I'm wrong here?

### Type checking

Typescript will check the JSON for us here, so if there is a missing required key in the JSON there will be a warning.

Here's what happened when I omitted a programId in the devnet DAO JSON for example.

![Screenshot 2021-12-09 at 8 21 51 PM](https://user-images.githubusercontent.com/601961/145471907-553171a0-d7c3-4b98-be89-cebc79ad8442.png)

If we added `yarn type-check` as a CI check it would also detect bad data and block the PR merge

![Screenshot 2021-12-09 at 8 50 09 PM](https://user-images.githubusercontent.com/601961/145473575-676e80ec-4f60-491e-9c94-2d73d2f5ad9c.png)