### PR TITLE
fix: WalletAdapter import path

### DIFF
--- a/@types/types.ts
+++ b/@types/types.ts
@@ -1,4 +1,4 @@
-import { AccountInfo, PublicKey } from '@solana/web3.js'
+import type { AccountInfo, PublicKey } from '@solana/web3.js'
 
 export interface EndpointInfo {
   name: string

--- a/utils/ataTools.tsx
+++ b/utils/ataTools.tsx
@@ -3,8 +3,8 @@ import {
   Token,
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
+import { WalletAdapter } from '@solana/wallet-adapter-base'
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
-import { WalletAdapter } from '../@types/types'
 import { ConnectionContext } from 'stores/useWalletStore'
 import { sendTransaction } from './send'
 import { tryGetAta, isExistingTokenAccount } from './validations'

--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -4,9 +4,9 @@ import {
   Token,
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
+import { WalletAdapter } from '@solana/wallet-adapter-base'
 import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { parseMintNaturalAmountFromDecimal } from '@tools/sdk/units'
-import { WalletAdapter } from '../@types/types'
 import { ConnectionContext } from 'stores/useWalletStore'
 import { findTrueReceiver } from './ataTools'
 import { isFormValid } from './formValidation'


### PR DESCRIPTION
fixes import path

![Screenshot 2021-12-15 at 6 21 57 PM](https://user-images.githubusercontent.com/601961/146244579-fd527715-40cf-49ca-afdc-2c3337a145a8.png)

1. changes import path for `WalletAdapter`
```diff
- import { WalletAdapter } from '../@types/types'
+ import { WalletAdapter } from '@solana/wallet-adapter-base'
```

2. renames `@types/types.tsx` to `@types/types.ts`

3. `import type` in types file
```diff
- import { AccountInfo, PublicKey } from '@solana/web3.js'
+ import type { AccountInfo, PublicKey } from '@solana/web3.js'
```